### PR TITLE
Add advanced stock analytics and filtering

### DIFF
--- a/config.js
+++ b/config.js
@@ -190,6 +190,10 @@ window.applyConfig = function(customConfig) {
 
 // Função para obter configuração específica
 window.getConfig = function(path) {
+    if (!path) {
+        return window.dashboardConfig;
+    }
+
     const keys = path.split('.');
     let current = window.dashboardConfig;
     

--- a/index.html
+++ b/index.html
@@ -424,7 +424,81 @@
             grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
             gap: 15px;
         }
-        
+
+        .pareto-section {
+            background: #f8f9fa;
+            padding: 15px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            border: 1px solid #e0e0e0;
+        }
+
+        .pareto-section h3 {
+            margin-top: 0;
+            margin-bottom: 15px;
+        }
+
+        .pareto-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .pareto-table th,
+        .pareto-table td {
+            text-align: left;
+            padding: 10px;
+            border-bottom: 1px solid #e0e0e0;
+            font-size: 13px;
+        }
+
+        .pareto-table th {
+            background: #e3f2fd;
+            color: #1F448C;
+        }
+
+        .pareto-empty {
+            margin: 0;
+            color: #666;
+            text-align: center;
+            font-size: 14px;
+        }
+
+        .abc-chip {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 32px;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-weight: bold;
+            font-size: 12px;
+            color: #fff;
+        }
+
+        .abc-chip.abc-a {
+            background-color: #f44336;
+        }
+
+        .abc-chip.abc-b {
+            background-color: #ff9800;
+        }
+
+        .abc-chip.abc-c {
+            background-color: #4caf50;
+        }
+
+        tr.abc-row-a {
+            box-shadow: inset 4px 0 0 #f44336;
+        }
+
+        tr.abc-row-b {
+            box-shadow: inset 4px 0 0 #ff9800;
+        }
+
+        tr.abc-row-c {
+            box-shadow: inset 4px 0 0 #4caf50;
+        }
+
         .stat-item {
             text-align: center;
             padding: 15px;
@@ -829,7 +903,16 @@
                     <option value="90-15">90-15 (GARUVA)</option>
                 </select>
             </div>
-            
+
+            <div class="control-group">
+                <label>Filtro avançado:</label>
+                <select id="advancedStockFilter" onchange="filterByAdvancedStock()">
+                    <option value="">Todos os produtos</option>
+                    <option value="no-stock">Sem estoque</option>
+                    <option value="over50">Estoque &gt; 50 meses</option>
+                </select>
+            </div>
+
             <div class="control-group">
                 <button onclick="showExportModal()">📤 Exportar</button>
                 <button onclick="updateData()">🔄 Atualizar</button>
@@ -842,16 +925,16 @@
                 <h4>⚠️ Alertas Preditivos</h4>
                 <div id="predictionAlerts">
                     <div class="prediction-item clickable" onclick="filterZeroIn30()" title="Clique para filtrar produtos">
-                        <span class="prediction-label">Produtos zerando em 30 dias:</span>
+                        <span class="prediction-label">Produtos zerando em <span id="urgentDaysLabel">30</span> dias:</span>
                         <span class="prediction-value prediction-critical" id="zeroIn30">0</span>
                     </div>
                     <div class="prediction-item clickable" onclick="filterZeroIn60()" title="Clique para filtrar produtos">
-                        <span class="prediction-label">Produtos zerando em 60 dias:</span>
+                        <span class="prediction-label">Produtos zerando em <span id="warningDaysLabel">60</span> dias:</span>
                         <span class="prediction-value prediction-warning" id="zeroIn60">0</span>
                     </div>
                     <div class="prediction-item">
                         <span class="prediction-label">Ponto de reposição ideal:</span>
-                        <span class="prediction-value prediction-good" id="reorderPoint">3-4 meses</span>
+                        <span class="prediction-value prediction-good" id="reorderPoint">--</span>
                     </div>
                 </div>
             </div>
@@ -868,6 +951,22 @@
                     <div class="stat-value" id="avgStockMonths">0.0</div>
                     <div class="stat-label">Média de Estoque (meses)</div>
                 </div>
+                <div class="stat-item">
+                    <div class="stat-value" id="medianStock">--</div>
+                    <div class="stat-label">Mediana de Estoque (meses)</div>
+                </div>
+                <div class="stat-item">
+                    <div class="stat-value" id="q1Stock">--</div>
+                    <div class="stat-label">1º Quartil (25%)</div>
+                </div>
+                <div class="stat-item">
+                    <div class="stat-value" id="q3Stock">--</div>
+                    <div class="stat-label">3º Quartil (75%)</div>
+                </div>
+                <div class="stat-item">
+                    <div class="stat-value" id="stdDevStock">--</div>
+                    <div class="stat-label">Desvio-Padrão (meses)</div>
+                </div>
                 <div class="stat-item clickable" onclick="filterCriticalStock()" title="Clique para ver produtos críticos (<2 meses)">
                     <div class="stat-value critical" id="criticalCount">0</div>
                     <div class="stat-label">Produtos Críticos</div>
@@ -879,6 +978,10 @@
             </div>
         </div>
         
+        <div class="pareto-section">
+            <h3>📊 Análise ABC por Vendas</h3>
+            <div id="paretoContent"></div>
+        </div>
         <div class="gauges-container" id="gaugesContainer">
         </div>
         
@@ -904,6 +1007,7 @@
                             <th>Meses</th>
                             <th>Previsão</th>
                             <th>Status</th>
+                            <th>Classe ABC</th>
                         </tr>
                     </thead>
                     <tbody id="productsTableBody">
@@ -940,6 +1044,7 @@
 
     <!-- Inclusão das bibliotecas -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <script src="config.js"></script>
     
     <script>
         // Variáveis globais
@@ -957,6 +1062,8 @@
         let debugMode = false;
         let mappingDebugMode = false;
         let lastMappingInfo = null;
+        let advancedStockFilter = '';
+        let abcClassificationMap = new Map();
 
         // Função de log para debug
         function debugLog(message, type) {
@@ -1001,28 +1108,148 @@
         function showMappingInfo(mappingInfo) {
             const mappingDiv = document.getElementById('mappingDebug');
             if (!mappingDiv || !mappingDebugMode) return;
-            
+
             let html = '<strong>📋 INFORMAÇÕES DE MAPEAMENTO DE COLUNAS</strong><br><br>';
             html += `<strong>Colunas encontradas na planilha:</strong><br>`;
             mappingInfo.headers.forEach((header, index) => {
                 html += `[${index}] "${header}"<br>`;
             });
-            
+
             html += '<br><strong>Mapeamento aplicado:</strong><br>';
             for (const [field, index] of Object.entries(mappingInfo.mapping)) {
                 const header = mappingInfo.headers[index] || 'ÍNDICE INVÁLIDO';
                 const status = mappingInfo.headers[index] ? '✅' : '❌';
                 html += `${field} → [${index}] "${header}" ${status}<br>`;
             }
-            
+
             if (mappingInfo.warnings.length > 0) {
                 html += '<br><strong>⚠️ Avisos:</strong><br>';
                 mappingInfo.warnings.forEach(warning => {
                     html += `${warning}<br>`;
                 });
             }
-            
+
             mappingDiv.innerHTML = html;
+        }
+
+        function getConfigValue(path, fallback) {
+            if (typeof getConfig === 'function') {
+                const value = getConfig(path);
+                if (typeof value !== 'undefined') {
+                    return value;
+                }
+            } else if (window.dashboardConfig) {
+                const keys = path.split('.');
+                let current = window.dashboardConfig;
+                for (const key of keys) {
+                    if (current && typeof current === 'object' && key in current) {
+                        current = current[key];
+                    } else {
+                        current = undefined;
+                        break;
+                    }
+                }
+                if (typeof current !== 'undefined') {
+                    return current;
+                }
+            }
+
+            return fallback;
+        }
+
+        function getPredictionSettings() {
+            const defaults = { urgentDays: 30, warningDays: 60 };
+            const configValues = getConfigValue('predictions', {}) || {};
+            return Object.assign({}, defaults, {
+                urgentDays: typeof configValues.urgentDays === 'number' ? configValues.urgentDays : defaults.urgentDays,
+                warningDays: typeof configValues.warningDays === 'number' ? configValues.warningDays : defaults.warningDays
+            });
+        }
+
+        function getReorderPointValue() {
+            const reorder = getConfigValue('stockLevels.reorderPoint', null);
+            return typeof reorder === 'number' ? reorder : null;
+        }
+
+        function calculateDailyDemand(product) {
+            const monthlyAverage = product.media3M && product.media3M > 0
+                ? product.media3M
+                : (product.vendas4M && product.vendas4M > 0 ? product.vendas4M / 4 : 0);
+
+            if (monthlyAverage > 0) {
+                return monthlyAverage / 30;
+            }
+
+            if (product.stockMonths && product.stockMonths > 0) {
+                const totalStock = (product.stock14 || 0) + (product.stock9013 || 0) + (product.stock9015 || 0);
+                const inferredDaily = totalStock / (product.stockMonths * 30);
+                return isFinite(inferredDaily) && inferredDaily > 0 ? inferredDaily : 0;
+            }
+
+            return 0;
+        }
+
+        function getCoverageInfo(product) {
+            const stockAvailable = getProductStock(product);
+            const dailyDemand = calculateDailyDemand(product);
+
+            if (stockAvailable <= 0) {
+                return {
+                    stockAvailable,
+                    dailyDemand,
+                    daysToDepletion: 0,
+                    hasDemand: dailyDemand > 0,
+                    outOfStock: true
+                };
+            }
+
+            if (dailyDemand <= 0) {
+                return {
+                    stockAvailable,
+                    dailyDemand,
+                    daysToDepletion: null,
+                    hasDemand: false,
+                    outOfStock: false
+                };
+            }
+
+            return {
+                stockAvailable,
+                dailyDemand,
+                daysToDepletion: stockAvailable / dailyDemand,
+                hasDemand: true,
+                outOfStock: false
+            };
+        }
+
+        function formatStatValue(value, digits = 1) {
+            if (value === null || typeof value === 'undefined' || Number.isNaN(value)) {
+                return '--';
+            }
+
+            return value.toFixed(digits);
+        }
+
+        function applyPredictionLabels() {
+            const { urgentDays, warningDays } = getPredictionSettings();
+            const urgentLabel = document.getElementById('urgentDaysLabel');
+            const warningLabel = document.getElementById('warningDaysLabel');
+            const reorderElement = document.getElementById('reorderPoint');
+            const reorderPointValue = getReorderPointValue();
+
+            if (urgentLabel) {
+                urgentLabel.textContent = urgentDays;
+            }
+
+            if (warningLabel) {
+                warningLabel.textContent = warningDays;
+            }
+
+            if (reorderElement) {
+                reorderElement.textContent = typeof reorderPointValue === 'number'
+                    ? `${reorderPointValue} meses`
+                    : '--';
+            }
         }
 
         // Detectar suporte ao File System Access API
@@ -2091,6 +2318,8 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
             document.getElementById('familyFilter').value = '';
             document.getElementById('supplierFilter').value = '';
             document.getElementById('establishmentFilter').value = '';
+            document.getElementById('advancedStockFilter').value = '';
+            advancedStockFilter = '';
             updateActiveButton('all');
             applyAllFilters();
         }
@@ -2158,6 +2387,13 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
             applyAllFilters();
         }
 
+        function filterByAdvancedStock() {
+            const advancedDropdown = document.getElementById('advancedStockFilter');
+            advancedStockFilter = advancedDropdown ? advancedDropdown.value : '';
+            criticalFilterActive = false;
+            applyAllFilters();
+        }
+
         function filterByGauge(family) {
             if (selectedFamily === family) {
                 selectedFamily = null;
@@ -2218,14 +2454,29 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
 
         function applyAllFilters() {
             let baseData = allProductsData.slice();
+            const { urgentDays, warningDays } = getPredictionSettings();
 
             if (predictionFilter === 'zero30') {
                 baseData = baseData.filter(function(p) {
-                    return p.stockMonths > 0 && p.stockMonths < 1;
+                    const coverage = getCoverageInfo(p);
+                    if (coverage.outOfStock) {
+                        return true;
+                    }
+                    if (coverage.daysToDepletion === null) {
+                        return false;
+                    }
+                    return coverage.daysToDepletion <= urgentDays;
                 });
             } else if (predictionFilter === 'zero60') {
                 baseData = baseData.filter(function(p) {
-                    return p.stockMonths >= 1 && p.stockMonths < 2;
+                    const coverage = getCoverageInfo(p);
+                    if (coverage.outOfStock) {
+                        return false;
+                    }
+                    if (coverage.daysToDepletion === null) {
+                        return false;
+                    }
+                    return coverage.daysToDepletion > urgentDays && coverage.daysToDepletion <= warningDays;
                 });
             }
 
@@ -2272,11 +2523,30 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
 
             if (currentEstablishment) {
                 baseData = baseData.filter(function(product) {
-                    return getProductStock(product) > 0;
+                    const stock = getProductStock(product);
+                    if (advancedStockFilter === 'no-stock') {
+                        return stock <= 0;
+                    }
+                    return stock > 0;
+                });
+            }
+
+            if (advancedStockFilter === 'no-stock') {
+                baseData = baseData.filter(function(product) {
+                    return getProductStock(product) <= 0;
+                });
+            } else if (advancedStockFilter === 'over50') {
+                baseData = baseData.filter(function(product) {
+                    const coverage = getCoverageInfo(product);
+                    if (coverage.daysToDepletion !== null) {
+                        return (coverage.daysToDepletion / 30) > 50;
+                    }
+                    return product.stockMonths > 50;
                 });
             }
 
             filteredData = baseData;
+            updateParetoAnalysis();
             updateTable();
             updateSummary();
             updateGauges();
@@ -2295,32 +2565,60 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
 
         // === FUNÇÕES DE ANÁLISE ===
         function updatePredictiveAnalysis() {
-            const thirtyDayZero = filteredData.filter(function(p) {
-                return p.stockMonths > 0 && p.stockMonths < 1;
-            }).length;
-            const sixtyDayZero = filteredData.filter(function(p) {
-                return p.stockMonths >= 1 && p.stockMonths < 2;
-            }).length;
+            applyPredictionLabels();
 
-            document.getElementById('zeroIn30').textContent = thirtyDayZero;
-            document.getElementById('zeroIn60').textContent = sixtyDayZero;
+            const { urgentDays, warningDays } = getPredictionSettings();
+            let urgentCount = 0;
+            let warningCount = 0;
+
+            filteredData.forEach(function(product) {
+                const coverage = getCoverageInfo(product);
+
+                if (coverage.outOfStock) {
+                    urgentCount++;
+                    return;
+                }
+
+                if (coverage.daysToDepletion === null) {
+                    return;
+                }
+
+                if (coverage.daysToDepletion <= urgentDays) {
+                    urgentCount++;
+                } else if (coverage.daysToDepletion <= warningDays) {
+                    warningCount++;
+                }
+            });
 
             const zeroIn30Element = document.getElementById('zeroIn30');
             const zeroIn60Element = document.getElementById('zeroIn60');
-            
-            zeroIn30Element.className = thirtyDayZero > 10 ? 'prediction-value prediction-critical' : 
-                                      thirtyDayZero > 5 ? 'prediction-value prediction-warning' : 
-                                      'prediction-value prediction-good';
-            
-            zeroIn60Element.className = sixtyDayZero > 15 ? 'prediction-value prediction-warning' : 
-                                       'prediction-value prediction-good';
-        }
 
+            if (zeroIn30Element) {
+                zeroIn30Element.textContent = urgentCount;
+                zeroIn30Element.className = urgentCount > 0
+                    ? 'prediction-value prediction-critical'
+                    : 'prediction-value prediction-good';
+            }
+
+            if (zeroIn60Element) {
+                zeroIn60Element.textContent = warningCount;
+                zeroIn60Element.className = warningCount > 0
+                    ? 'prediction-value prediction-warning'
+                    : 'prediction-value prediction-good';
+            }
+        }
         function updateSummary() {
             const total = filteredData.length;
-            const avgStock = total > 0 ? filteredData.reduce(function(sum, p) {
-                return sum + p.stockMonths;
-            }, 0) / total : 0;
+            const monthsValues = filteredData
+                .map(function(p) { return typeof p.stockMonths === 'number' ? p.stockMonths : null; })
+                .filter(function(value) { return value !== null && !Number.isNaN(value); })
+                .sort(function(a, b) { return a - b; });
+
+            const sumMonths = monthsValues.reduce(function(sum, value) {
+                return sum + value;
+            }, 0);
+
+            const avgStock = monthsValues.length > 0 ? sumMonths / monthsValues.length : 0;
             const criticalCount = filteredData.filter(function(p) {
                 return p.stockMonths < 2;
             }).length;
@@ -2328,10 +2626,122 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                 return p.family;
             })).size;
 
+            function percentile(arr, fraction) {
+                if (arr.length === 0) return null;
+                const position = (arr.length - 1) * fraction;
+                const base = Math.floor(position);
+                const rest = position - base;
+                const baseValue = arr[base];
+                const nextValue = arr[base + 1];
+                if (typeof nextValue === 'undefined') {
+                    return baseValue;
+                }
+                return baseValue + rest * (nextValue - baseValue);
+            }
+
+            const median = percentile(monthsValues, 0.5);
+            const q1 = percentile(monthsValues, 0.25);
+            const q3 = percentile(monthsValues, 0.75);
+            const variance = monthsValues.length > 0 ? monthsValues.reduce(function(acc, value) {
+                return acc + Math.pow(value - avgStock, 2);
+            }, 0) / monthsValues.length : 0;
+            const stdDev = monthsValues.length > 0 ? Math.sqrt(variance) : null;
+
             document.getElementById('totalProducts').textContent = total;
-            document.getElementById('avgStockMonths').textContent = avgStock.toFixed(1);
+            document.getElementById('avgStockMonths').textContent = monthsValues.length > 0 ? formatStatValue(avgStock) : '--';
+            document.getElementById('medianStock').textContent = median !== null ? formatStatValue(median) : '--';
+            document.getElementById('q1Stock').textContent = q1 !== null ? formatStatValue(q1) : '--';
+            document.getElementById('q3Stock').textContent = q3 !== null ? formatStatValue(q3) : '--';
+            document.getElementById('stdDevStock').textContent = stdDev !== null ? formatStatValue(stdDev) : '--';
             document.getElementById('criticalCount').textContent = criticalCount;
             document.getElementById('totalFamilies').textContent = families;
+        }
+
+        function updateParetoAnalysis() {
+            const container = document.getElementById('paretoContent');
+            abcClassificationMap = new Map();
+            if (!container) {
+                return;
+            }
+
+            if (!Array.isArray(filteredData) || filteredData.length === 0) {
+                container.innerHTML = '<p class="pareto-empty">Nenhum produto para análise.</p>';
+                abcClassificationMap = new Map();
+                return;
+            }
+
+            const sortedData = filteredData.slice().sort(function(a, b) {
+                return (b.vendas4M || 0) - (a.vendas4M || 0);
+            });
+            const totalSales = sortedData.reduce(function(sum, product) {
+                return sum + (product.vendas4M || 0);
+            }, 0);
+
+            if (totalSales === 0) {
+                sortedData.forEach(function(product) {
+                    abcClassificationMap.set(product.code, '—');
+                });
+                container.innerHTML = '<p class="pareto-empty">Sem dados de vendas para calcular a análise ABC.</p>';
+                return;
+            }
+
+            let cumulativeShare = 0;
+            const displayLimit = 10;
+            const rows = [];
+
+            sortedData.forEach(function(product, index) {
+                const sales = product.vendas4M || 0;
+                const individualShare = sales / totalSales;
+                cumulativeShare += individualShare;
+
+                let classification = 'C';
+                if (cumulativeShare <= 0.8) {
+                    classification = 'A';
+                } else if (cumulativeShare <= 0.95) {
+                    classification = 'B';
+                }
+
+                abcClassificationMap.set(product.code, classification);
+
+                if (index < displayLimit) {
+                    rows.push(`
+                        <tr>
+                            <td>${index + 1}</td>
+                            <td>${product.code}</td>
+                            <td>${product.item}</td>
+                            <td>${(product.vendas4M || 0).toLocaleString()}</td>
+                            <td>${(individualShare * 100).toFixed(1)}%</td>
+                            <td>${(cumulativeShare * 100).toFixed(1)}%</td>
+                            <td><span class="abc-chip abc-${classification.toLowerCase()}">${classification}</span></td>
+                        </tr>
+                    `);
+                }
+            });
+
+            const tableHtml = `
+                <table class="pareto-table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Código</th>
+                            <th>Item</th>
+                            <th>Vendas 4M</th>
+                            <th>% Individual</th>
+                            <th>% Acumulado</th>
+                            <th>Classe</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${rows.join('')}
+                    </tbody>
+                </table>
+            `;
+
+            const footer = sortedData.length > displayLimit
+                ? `<p class="pareto-empty">Exibindo top ${displayLimit} de ${sortedData.length} produtos.</p>`
+                : '';
+
+            container.innerHTML = tableHtml + footer;
         }
 
         function updateTable() {
@@ -2343,10 +2753,16 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                 const totalStock = product.stock14 + product.stock9013 + product.stock9015;
                 const statusClass = getStatusClass(product.stockMonths);
                 const prediction = getPrediction(product);
-                
+
                 const vendas4MDisplay = (!product.vendas4M || product.vendas4M === 0) ? 'S/ VENDA' : product.vendas4M.toLocaleString();
                 const vendas4MClass = (!product.vendas4M || product.vendas4M === 0) ? 'status-warning' : '';
-                
+
+                const abcClass = abcClassificationMap.get(product.code);
+                const normalizedAbcClass = (typeof abcClass === 'string' && abcClass) ? abcClass.toUpperCase() : '—';
+                const abcCellContent = normalizedAbcClass === '—'
+                    ? '—'
+                    : `<span class="abc-chip abc-${normalizedAbcClass.toLowerCase()}">${normalizedAbcClass}</span>`;
+
                 row.innerHTML = `
                     <td>${product.code}</td>
                     <td>${product.supplier}</td>
@@ -2361,9 +2777,20 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                     <td class="${statusClass}">${product.stockMonths.toFixed(1)}</td>
                     <td class="${statusClass}">${prediction}</td>
                     <td class="${statusClass}">${getStatusText(product.stockMonths)}</td>
-                    
+                    <td>${abcCellContent}</td>
+
                 `;
-                
+
+                if (normalizedAbcClass === 'A') {
+                    row.classList.add('abc-row-a');
+                } else if (normalizedAbcClass === 'B') {
+                    row.classList.add('abc-row-b');
+                } else if (normalizedAbcClass === 'C') {
+                    row.classList.add('abc-row-c');
+                }
+
+                row.dataset.abcClass = normalizedAbcClass;
+
                 tableBody.appendChild(row);
             });
 
@@ -2384,11 +2811,31 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
         }
 
         function getPrediction(product) {
-            if (product.stockMonths === 0) return 'Sem estoque';
-            if (product.stockMonths < 1) return 'Crítico - 30 dias';
-            if (product.stockMonths < 2) return 'Crítico - 60 dias';
-            if (product.stockMonths < 6) return 'Atenção - 90+ dias';
-            return 'Estável';
+            const coverage = getCoverageInfo(product);
+            const { urgentDays, warningDays } = getPredictionSettings();
+
+            if (coverage.outOfStock) {
+                return 'Sem estoque — ruptura imediata';
+            }
+
+            if (!coverage.hasDemand || coverage.daysToDepletion === null) {
+                return 'Sem demanda recente — cobertura indefinida';
+            }
+
+            const daysToDepletion = Math.max(1, Math.round(coverage.daysToDepletion));
+            const estimatedDate = new Date(Date.now() + daysToDepletion * 86400000);
+            const formattedDate = estimatedDate.toLocaleDateString('pt-BR');
+
+            if (daysToDepletion <= urgentDays) {
+                return `Crítico — ${daysToDepletion} dias (ruptura em ${formattedDate})`;
+            }
+
+            if (daysToDepletion <= warningDays) {
+                return `Atenção — ${daysToDepletion} dias (ruptura em ${formattedDate})`;
+            }
+
+            const monthsCoverage = coverage.daysToDepletion / 30;
+            return `Estável — ${formatStatValue(monthsCoverage)} meses (ruptura em ${formattedDate})`;
         }
 
         function getStatusClass(months) {
@@ -2734,7 +3181,8 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
             try {
                 // Primeiro detectar capacidades do navegador
                 detectBrowserCapabilities();
-                
+                applyPredictionLabels();
+
                 // Depois carregar dados
                 loadExternalDataScript();
                 


### PR DESCRIPTION
## Summary
- expose configuration values via getConfig to support dynamic prediction thresholds
- enhance the dashboard UI with advanced stock filters, extended summary statistics, and improved predictive messaging
- add an ABC Pareto sales analysis section with styling updates and table integration

## Testing
- Not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dc4304c940832ca277234dcb80418c