### PR TITLE
Padroniza tooltips e filtros ABC

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,6 +524,7 @@
             position: sticky;
             top: 0;
             border-bottom: 2px solid #ddd;
+            z-index: 5;
         }
         
         td {
@@ -1070,6 +1071,9 @@
                     <option value="">Todos os produtos</option>
                     <option value="no-stock">Sem estoque</option>
                     <option value="over50">Estoque &gt; 50 meses</option>
+                    <option value="abc-a">Classe A</option>
+                    <option value="abc-b">Classe B</option>
+                    <option value="abc-c">Classe C</option>
                 </select>
             </div>
 
@@ -1239,7 +1243,8 @@
             }
 
             const rect = target.getBoundingClientRect();
-            const prefersTop = target.getAttribute('data-tooltip-position') === 'top';
+            const desiredPosition = target.getAttribute('data-tooltip-position');
+            const prefersTop = desiredPosition !== 'bottom';
             tooltipElement.style.maxWidth = `min(320px, ${Math.max(200, window.innerWidth - 32)}px)`;
 
             const tooltipRect = tooltipElement.getBoundingClientRect();
@@ -2246,11 +2251,16 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
             selectedSupplier = null;
             currentEstablishment = '';
             criticalFilterActive = false;
-            
+            advancedStockFilter = '';
+
             document.getElementById('familyFilter').value = '';
             document.getElementById('supplierFilter').value = '';
             document.getElementById('establishmentFilter').value = '';
-            
+            const advancedDropdown = document.getElementById('advancedStockFilter');
+            if (advancedDropdown) {
+                advancedDropdown.value = '';
+            }
+
             updateActiveButton('all');
             
             const activeItems = document.querySelectorAll('.prediction-item.active');
@@ -2260,6 +2270,7 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
         }
 
         function clearSearch() {
+            resetAllFilters();
             document.getElementById('globalSearch').value = '';
             document.getElementById('searchResults').innerHTML = '';
             searchTerm = '';
@@ -2739,7 +2750,7 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
 
         function filterZeroIn60() {
             const item60 = document.querySelector('.prediction-item.clickable[onclick="filterZeroIn60()"]');
-            
+
             if (predictionFilter === 'zero60') {
                 predictionFilter = null;
                 item60.classList.remove('active');
@@ -2749,15 +2760,74 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                 activeItems.forEach(function(item) {
                     item.classList.remove('active');
                 });
-                
+
                 predictionFilter = 'zero60';
                 criticalFilterActive = false;
                 item60.classList.add('active');
                 currentFilter = 'prediction60';
                 updateActiveButton(null);
-                
+
                 applyAllFilters();
             }
+        }
+
+        function assignAbcClassification(dataSet) {
+            const classificationMap = new Map();
+
+            if (!Array.isArray(dataSet) || dataSet.length === 0) {
+                abcClassificationMap = classificationMap;
+                if (Array.isArray(dataSet)) {
+                    dataSet.forEach(function(product) {
+                        product.currentAbcClass = '—';
+                    });
+                }
+                return classificationMap;
+            }
+
+            const sortedData = dataSet.slice().sort(function(a, b) {
+                return (b.vendas4M || 0) - (a.vendas4M || 0);
+            });
+
+            const totalSales = sortedData.reduce(function(sum, product) {
+                return sum + (product.vendas4M || 0);
+            }, 0);
+
+            if (totalSales === 0) {
+                sortedData.forEach(function(product) {
+                    classificationMap.set(product.code, '—');
+                    product.currentAbcClass = '—';
+                });
+                abcClassificationMap = classificationMap;
+                return classificationMap;
+            }
+
+            let cumulativeShare = 0;
+
+            sortedData.forEach(function(product) {
+                const sales = product.vendas4M || 0;
+                const individualShare = totalSales === 0 ? 0 : sales / totalSales;
+                cumulativeShare += individualShare;
+
+                let classification = 'C';
+                if (cumulativeShare <= 0.8) {
+                    classification = 'A';
+                } else if (cumulativeShare <= 0.95) {
+                    classification = 'B';
+                }
+
+                classificationMap.set(product.code, classification);
+            });
+
+            dataSet.forEach(function(product) {
+                const classification = classificationMap.get(product.code) || '—';
+                product.currentAbcClass = classification;
+                if (!classificationMap.has(product.code)) {
+                    classificationMap.set(product.code, classification);
+                }
+            });
+
+            abcClassificationMap = classificationMap;
+            return classificationMap;
         }
 
         function applyAllFilters() {
@@ -2839,7 +2909,14 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                 });
             }
 
-            if (advancedStockFilter === 'no-stock') {
+            assignAbcClassification(baseData);
+
+            if (advancedStockFilter && advancedStockFilter.startsWith('abc-')) {
+                const desiredClass = advancedStockFilter.slice(4).toUpperCase();
+                baseData = baseData.filter(function(product) {
+                    return (product.currentAbcClass || '—') === desiredClass;
+                });
+            } else if (advancedStockFilter === 'no-stock') {
                 baseData = baseData.filter(function(product) {
                     return getProductStock(product) <= 0;
                 });
@@ -2963,14 +3040,12 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
 
         function updateParetoAnalysis() {
             const container = document.getElementById('paretoContent');
-            abcClassificationMap = new Map();
             if (!container) {
                 return;
             }
 
             if (!Array.isArray(filteredData) || filteredData.length === 0) {
                 container.innerHTML = '<p class="pareto-empty">Nenhum produto para análise.</p>';
-                abcClassificationMap = new Map();
                 return;
             }
 
@@ -2982,9 +3057,6 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
             }, 0);
 
             if (totalSales === 0) {
-                sortedData.forEach(function(product) {
-                    abcClassificationMap.set(product.code, '—');
-                });
                 container.innerHTML = '<p class="pareto-empty">Sem dados de vendas para calcular a análise ABC.</p>';
                 return;
             }
@@ -2998,14 +3070,14 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                 const individualShare = sales / totalSales;
                 cumulativeShare += individualShare;
 
-                let classification = 'C';
-                if (cumulativeShare <= 0.8) {
-                    classification = 'A';
-                } else if (cumulativeShare <= 0.95) {
-                    classification = 'B';
-                }
-
-                abcClassificationMap.set(product.code, classification);
+                const rawClass = (typeof product.currentAbcClass === 'string' && product.currentAbcClass)
+                    ? product.currentAbcClass.toUpperCase()
+                    : '—';
+                const isValidClass = rawClass === 'A' || rawClass === 'B' || rawClass === 'C';
+                const classification = isValidClass ? rawClass : '—';
+                const classificationCell = isValidClass
+                    ? `<span class="abc-chip abc-${classification.toLowerCase()}">${classification}</span>`
+                    : '—';
 
                 if (index < displayLimit) {
                     rows.push(`
@@ -3016,7 +3088,7 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                             <td>${(product.vendas4M || 0).toLocaleString()}</td>
                             <td>${(individualShare * 100).toFixed(1)}%</td>
                             <td>${(cumulativeShare * 100).toFixed(1)}%</td>
-                            <td><span class="abc-chip abc-${classification.toLowerCase()}">${classification}</span></td>
+                            <td>${classificationCell}</td>
                         </tr>
                     `);
                 }
@@ -3065,11 +3137,17 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
                 const vendas4MDisplay = (!product.vendas4M || product.vendas4M === 0) ? 'S/ VENDA' : product.vendas4M.toLocaleString();
                 const vendas4MClass = (!product.vendas4M || product.vendas4M === 0) ? 'status-warning' : '';
 
-                const abcClass = abcClassificationMap.get(product.code);
-                const normalizedAbcClass = (typeof abcClass === 'string' && abcClass) ? abcClass.toUpperCase() : '—';
-                const abcCellContent = normalizedAbcClass === '—'
-                    ? '—'
-                    : `<span class="abc-chip abc-${normalizedAbcClass.toLowerCase()}">${normalizedAbcClass}</span>`;
+                const fallbackAbcClass = abcClassificationMap.get(product.code);
+                const rawAbcClass = (typeof product.currentAbcClass === 'string' && product.currentAbcClass)
+                    ? product.currentAbcClass
+                    : fallbackAbcClass;
+                const normalizedAbcClass = (typeof rawAbcClass === 'string' && rawAbcClass)
+                    ? rawAbcClass.toUpperCase()
+                    : '—';
+                const isValidAbcClass = normalizedAbcClass === 'A' || normalizedAbcClass === 'B' || normalizedAbcClass === 'C';
+                const abcCellContent = isValidAbcClass
+                    ? `<span class="abc-chip abc-${normalizedAbcClass.toLowerCase()}">${normalizedAbcClass}</span>`
+                    : '—';
 
                 row.innerHTML = `
                     <td>${product.code}</td>
@@ -3483,6 +3561,17 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
         }
 
         function updateData() {
+            resetAllFilters();
+            const searchInput = document.getElementById('globalSearch');
+            if (searchInput) {
+                searchInput.value = '';
+            }
+            const resultsDiv = document.getElementById('searchResults');
+            if (resultsDiv) {
+                resultsDiv.innerHTML = '';
+            }
+            searchTerm = '';
+            applyAllFilters();
             loadData();
             showMessage('✅ Dashboard atualizado!', 'success');
         }


### PR DESCRIPTION
## Summary
- Padroniza o posicionamento dos tooltips e aumenta o z-index do cabeçalho da tabela para evitar sobreposições.
- Adiciona filtros de Classe ABC no seletor avançado e garante que limpar/atualizar remova todos os filtros ativos.
- Calcula e reaproveita a classificação ABC para permitir filtragem dedicada e manter a tabela/Pareto sincronizados.

## Testing
- No automated tests were run (not applicable).


------
https://chatgpt.com/codex/tasks/task_e_68dd62b0a66c832c99eb64ca9975e441