### PR TITLE
Preserve ABC share when filtering by class

### DIFF
--- a/index.html
+++ b/index.html
@@ -3105,11 +3105,30 @@ console.log('data.js v1.2 carregado com', window.stockData.length, 'produtos');`
 
             const displayLimit = 10;
             const rows = [];
+            const normalizeShare = function(value) {
+                if (!Number.isFinite(value)) {
+                    return 0;
+                }
+                if (value < 0) {
+                    return 0;
+                }
+                if (value > 1) {
+                    return 1;
+                }
+                return value;
+            };
 
             sortedData.forEach(function(product, index) {
                 const sales = Math.max(product.vendas4M || 0, 0);
-                const individualShare = totalSales === 0 ? 0 : sales / totalSales;
-                product.individualSalesShare = individualShare;
+                const hasStoredShare = typeof product.individualSalesShare === 'number' && Number.isFinite(product.individualSalesShare);
+                const fallbackShare = totalSales === 0 ? 0 : sales / totalSales;
+                const individualShare = hasStoredShare
+                    ? normalizeShare(product.individualSalesShare)
+                    : normalizeShare(fallbackShare);
+
+                if (!hasStoredShare) {
+                    product.individualSalesShare = individualShare;
+                }
 
                 const rawClass = (typeof product.currentAbcClass === 'string' && product.currentAbcClass)
                     ? product.currentAbcClass.toUpperCase()


### PR DESCRIPTION
## Summary
- keep the ABC analysis % Individual consistent by reusing the pre-calculated share
- prevent the Pareto table from recalculating and inflating percentages when applying class filters

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68decc1dc0a0832cbbbec32455815be9